### PR TITLE
Update swinfo.json

### DIFF
--- a/toggle_notifications/swinfo.json
+++ b/toggle_notifications/swinfo.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "source": "https://github.com/cvusmo/Toggle-Notifications",
   "version": "0.2.1",
-  "version_check": "https://raw.githubusercontent.com/cvusmo/Toggle-Notifications/master/Toggle_Notifications/swinfo.json",
+  "version_check": "https://raw.githubusercontent.com/cvusmo/Toggle-Notifications/master/toggle_notifications/swinfo.json",
   "dependencies": [
     {
       "id": "SpaceWarp",


### PR DESCRIPTION
Fix version_check URL, it has upper case where the repo has lower case. This is causing an error when CKAN looks at this mod (and probably causes issues for SpaceDock as well, at the very least breaking the `version_check` functionality itself).

Found while working on KSP-CKAN/KSP2-NetKAN#53.